### PR TITLE
Connect Prometheus to Grafana Cloud

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -22,6 +22,19 @@ Run `terraform output` for information about entry points.
 
 [radicle-registry]: https://github.com/radicle-dev/radicle-registry
 
+Monitoring
+----------
+
+We use [Grafana Cloud][grafana-cloud] to monitor the Registry nodes. You can
+find the Grafana instance at [`radicle.grafana.net`][radicle-grafaa]
+
+We monitor the underlying infrastructure (Kubernetes and VMs) with [Stack
+Driver][stack-driver]
+
+[grafana-cloud]: https://grafana.com/orgs/radicle/api-keys
+[stack-driver]: https://console.cloud.google.com/monitoring?project=radicle-registry-dev
+[radicle-grafana]: https://radicle.grafana.net
+
 Container Images
 ----------------
 

--- a/registry/prometheus.yaml
+++ b/registry/prometheus.yaml
@@ -1,6 +1,12 @@
 global:
   scrape_interval: 5s
 
+remote_write:
+- url: https://prometheus-us-central1.grafana.net/api/prom/push
+  basic_auth:
+    username: 10831
+    password_file: /var/run/secrets/grafana-cloud-api-key/api-key
+
 scrape_configs:
 - job_name: radicle-registry-nodes
   kubernetes_sd_configs:

--- a/registry/secrets.yaml
+++ b/registry/secrets.yaml
@@ -1,0 +1,14 @@
+# `radicle-registry-devnet` API key from https://grafana.com/orgs/radicle/api-keys
+grafana_cloud_devnet_prometheus: ENC[AES256_GCM,data:SIKfSPYcCdZ/syARDRvb+jyVKUkM0ugdzJ579Sok/Mmk+bl9a0zGZaIV97wT0LQ48RxPG9+gl/6Shh0cDimBOFSBqYB61bbPRuMPo4VIU6cEUo6ljMXYAh4XvT6dvmM/7/CcDr1OoDXxBxUioHbtA1VfK9dOsL+u,iv:nQN44lkFmHkob3xJ1n9+0tbIW9n+/O7nq7WngalUy7k=,tag:44NXGCS4kD3lOB/rQAJeow==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+    -   resource_id: projects/radicle-registry-dev/locations/global/keyRings/dev/cryptoKeys/radicle-infra-repo
+        created_at: '2020-04-02T15:20:23Z'
+        enc: CiQAq/dbmWMZ621L3KTaFurh3drNYHYovN/zipVorIixIZOJUpASSQAOnCppUB4j4tzZ3Yn2PLfj1Ly71+y0pHLXX/q2qgjP0Xy8uwZyvs+gM+VcMTit39rWAdvZf8p+gMkahVWW3qXm52kn3nXbfAc=
+    azure_kv: []
+    lastmodified: '2020-04-03T10:40:13Z'
+    mac: ENC[AES256_GCM,data:6TQj2I9FpWRAVatJSvduWBbFiFypXdUaUJXtfD5P1miADe6w9YbG7CrhkXHMD90Up3JBgMT0+UfmJktEUNKX1NYMIseSqvLqrbayDUqETkX28zaW1MkBWWWU3r2G1acwmPCfzSi1uuATIQ0mEgj5AC0gOjocaePvW5DIDjyZIII=,iv:n+aHwkQ5hRjrEwYHmiuJHhLsjTMaeSQmnJrr6erFcW0=,tag:EB9wzmT3pjEZx4BbznBMMw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.5.0


### PR DESCRIPTION
_Based on #74. Only the last commit is relevant_

We start sending our metrics to Grafana Cloud by adding a `remote_write` section to our Prometheus configuration.