### PR TITLE
Add kubernetes_cluster label for metrics

### DIFF
--- a/registry/prometheus.yaml
+++ b/registry/prometheus.yaml
@@ -6,6 +6,11 @@ remote_write:
   basic_auth:
     username: 10831
     password_file: /var/run/secrets/grafana-cloud-api-key/api-key
+  write_relabel_configs:
+  - action: replace
+    target_label: kubernetes_cluster
+    replacement: devnet
+
 
 scrape_configs:
 - job_name: radicle-registry-nodes


### PR DESCRIPTION
To better distinguish metrics from different clusters we label them with the cluster name.