### PR TITLE
Domain names for boot nodes

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -15,6 +15,7 @@ Managed Infrastructure
 * GKE cluster `radicle-registry-devnet` for running a devnet that we can play
   around with. See `./devnet`.
 * GKE cluster `radicle-registry-ffnet` for running the FFnet information. See `./ffnet`.
+* DNS zones in `./dns.tf`
 
 Run `terraform output` for information about entry points.
 

--- a/registry/dns.tf
+++ b/registry/dns.tf
@@ -1,0 +1,10 @@
+# This domain is provided by Namecheap
+resource "google_dns_managed_zone" "radicle-network" {
+  name     = "radicle-network"
+  dns_name = "radicle.network."
+}
+
+output "radicle-network-nameservers" {
+  value       = google_dns_managed_zone.radicle-network.name_servers
+  description = "Name server to set on the radicle.network domain on Namecheap"
+}

--- a/registry/ffnet/README.md
+++ b/registry/ffnet/README.md
@@ -5,10 +5,11 @@ This module describes the infrastructure for the Radicle Registry FFnet.
 
 * [Kubernetes cluster](./main.tf) on Google Cloud Platform
 * Stateful [validator nodes](./validators.tf). The nodes have static P2P IDs and
-  the P2P endpoints are publicly exposed through load balancers.
+  the P2P endpoints are publicly exposed through load balancers. See `terraform
+  output` for the addresses
 * [Miner deployment](./miners.tf) running on a dedicated node pool of
   preemptible [`c2` instances][c2-instances].
 * A [Prometheus instance](./monitoring.tf) that collects metrics and forwards them
-  to [Grafana Cloud][https://radicle.grafana.net].
+  to [Grafana Cloud](https://radicle.grafana.net).
 
 [c2-instances]: https://cloud.google.com/compute/docs/machine-types#c2_machine_types

--- a/registry/ffnet/boot.tf
+++ b/registry/ffnet/boot.tf
@@ -1,0 +1,65 @@
+# Expose P2P endpoints of the validator nodes as boot nodes. See the output for
+# the boot node addresses.
+
+
+output "boot-node-addresses" {
+  value = [
+    "/dns4/${google_dns_record_set.boot[0].name}/tcp/30333/p2p/QmdEvLkAS8mxETQy1RCbdmcPPzxSs9RbExFcWvwJZDXxjG",
+    "/dns4/${google_dns_record_set.boot[1].name}/tcp/30333/p2p/QmceS5WYfDyKNtnzrxCw4TEL9nokvJkRi941oUzBvErsuD"
+  ]
+}
+
+resource "kubernetes_service" "boot" {
+  for_each = toset([
+    "0", "1"
+  ])
+
+  metadata {
+    name = "boot-${each.key}"
+  }
+
+  spec {
+    type             = "LoadBalancer"
+    load_balancer_ip = google_compute_address.ffnet-boot[each.key].address
+
+    selector = {
+      app                                  = "validator"
+      "statefulset.kubernetes.io/pod-name" = "validator-${each.key}"
+    }
+
+    port {
+      name        = "p2p"
+      port        = 30333
+      target_port = "p2p"
+    }
+  }
+}
+
+resource "google_compute_address" "ffnet-boot" {
+  for_each = toset([
+    "0", "1"
+  ])
+  name = "ffnet-boot-${each.key}"
+}
+
+variable "dns" {
+  type = object({
+    managed_zone = string
+    domain       = string
+  })
+}
+
+resource "google_dns_record_set" "boot" {
+  for_each = toset([
+    "0", "1"
+  ])
+  name         = "boot-${each.key}.ff.${var.dns.domain}"
+  managed_zone = var.dns.managed_zone
+
+  type = "A"
+  ttl  = 600
+
+  rrdatas = [google_compute_address.ffnet-boot[each.key].address]
+}
+
+

--- a/registry/ffnet/validators.tf
+++ b/registry/ffnet/validators.tf
@@ -1,30 +1,4 @@
-# Statefulset of two validator nodes. The P2P ports of the nodes are exposed
-# through a `LoadBalancer`.
-
-resource "kubernetes_service" "boot" {
-  for_each = toset([
-    "0", "1"
-  ])
-
-  metadata {
-    name = "boot-${each.key}"
-  }
-
-  spec {
-    type = "LoadBalancer"
-
-    selector = {
-      app                                  = "validator"
-      "statefulset.kubernetes.io/pod-name" = "validator-${each.key}"
-    }
-
-    port {
-      name        = "p2p"
-      port        = 30333
-      target_port = "p2p"
-    }
-  }
-}
+# Statefulset of two validator nodes.
 
 # Headless service to be able to address the nodes with DNS.
 resource "kubernetes_service" "validator" {

--- a/registry/main.tf
+++ b/registry/main.tf
@@ -9,6 +9,14 @@ module "devnet" {
 module "ffnet" {
   source  = "./ffnet"
   project = local.project
+  dns = {
+    domain       = google_dns_managed_zone.radicle-network.dns_name
+    managed_zone = google_dns_managed_zone.radicle-network.name
+  }
+}
+
+output "ffnet-boot-node-addresses" {
+  value = module.ffnet.boot-node-addresses
 }
 
 provider "google" {


### PR DESCRIPTION
We add DNS entries `boot-X.ff.radicle.network` that point to two validators of the FFnet. Run `terraform output` to get the addresses to pass to a node.