### PR TITLE
registry: Add labels to devnet miner deployment

### DIFF
--- a/registry/devnet/miners.tf
+++ b/registry/devnet/miners.tf
@@ -21,6 +21,9 @@ resource "kubernetes_deployment" "devnet-miner" {
   metadata {
     name      = "miner"
     namespace = kubernetes_namespace.devnet.metadata[0].name
+    labels = {
+      app = "miner"
+    }
   }
 
   spec {


### PR DESCRIPTION
We add the “app” label to the devnet miner deployment. Kubernetes does this automatically even if it is not specified in terraform. So when to avoid unnecessary diffs we add it to terraform.