### PR TITLE
Identify artifacts by BUILDKITE_TAG

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -101,9 +101,9 @@ the `Dockerfile` as its context, i.e. you can only `ADD` files from there. It is
 also possible to override the context by defining the `STEP_DOCKER_CONTEXT` env
 variable.
 
-The built image is tagged with the name given by `STEP_DOCKER_IMAGE` and the git
-commit hash `BUILDKITE_COMMIT` as the tag. The agent pushes the image to a
-registry deduced from `DOCKER_IMAGE`.
+For branch builds the image is pushed to `$STEP_DOCKER_IMAGE:$BUILDKITE_COMMIT`.
+For builds of a git tag the image is pushed to
+`$STEP_DOCKER_IMAGE:$BUILDKITE_TAG`.
 
 When building most of the [Buildkite environment variables][buildkite-env] are
 available as [build arguments][docker-build-args].
@@ -144,12 +144,22 @@ are stored in a publicly readable Monadic-managed GCS bucket.
 Artifacts uploaded by a `master` (that is, `$BUILDKITE_PIPELINE_DEFAULT_BRANCH`)
 builds will have a predictable URL, e.g.:
 
-`https://builds.radicle.xyz/radicle-registry/master/$BUILDKITE_COMMIT/$ARTIFACT_PATH`
+```
+https://builds.radicle.xyz/radicle-registry/master/$BUILDKITE_COMMIT/$ARTIFACT_PATH`
+```
+
+Artifacts uploaded by a git tag build will be uploaded to
+
+```
+https://builds.radicle.xyz/radicle-registry/$BUILDKITE_TAG/$ARTIFACT_PATH
+```
 
 All other artifacts are scoped by `$BUILDKITE_JOB_ID`, and best discovered
 through the Buildkite UI or API. E.g.:
 
-`https://builds.radicle.xyz/radicle-registry/b2d9d6fd-cc6a-4c44-90e4-b07b5c50ee4c/$ARTIFACT_PATH`
+```
+https://builds.radicle.xyz/radicle-registry/b2d9d6fd-cc6a-4c44-90e4-b07b5c50ee4c/$ARTIFACT_PATH`
+```
 
 ## macOS build agents
 

--- a/ci/linux/etc/buildkite-agent/hooks/command
+++ b/ci/linux/etc/buildkite-agent/hooks/command
@@ -254,9 +254,15 @@ if [[ -n ${STEP_DOCKER_FILE:-} ]]
 then
     if [[ -n ${STEP_DOCKER_IMAGE:-} ]]
     then
+        if [[ -n "${BUILDKITE_TAG}" ]]
+        then
+          tag="${BUILDKITE_TAG}"
+        else
+          tag="${BUILDKITE_COMMIT}"
+        fi
         echo "--- Build container image artifact"
         build_docker_image \
-            "${STEP_DOCKER_IMAGE}:${BUILDKITE_COMMIT}" \
+            "${STEP_DOCKER_IMAGE}:${tag}" \
             "${STEP_DOCKER_FILE}" \
             "${STEP_DOCKER_CONTEXT:-$(dirname "$STEP_DOCKER_FILE")}"
     else

--- a/ci/linux/etc/buildkite-agent/hooks/environment
+++ b/ci/linux/etc/buildkite-agent/hooks/environment
@@ -9,6 +9,13 @@ declare -i timeout_minutes=$MIN_TIMEOUT_MINUTES
 declare -ri CACHE_QUOTA_GiB=8
 declare -r cache_volume_prefix="cache_${BUILDKITE_AGENT_NAME}_${BUILDKITE_ORGANIZATION_SLUG}_${BUILDKITE_PIPELINE_SLUG}"
 
+if [[ -n "${BUILDKITE_TAG}" && ! ( "${BUILDKITE_TAG}" =~ ^[a-zA-Z][a-zA-Z0-9._\-]*$ ) ]]
+then
+  echo "Refusing to build for ill-formatted tag ${BUILDKITE_TAG}"
+  echo "Tag must match ^[a-zA-Z][a-zA-Z0-9._\\-]*$"
+  exit 1
+fi
+
 if [[ "${SHARED_MASTER_CACHE:-}" = "true" ]]; then
   declare -r shared_cache_volume_prefix="cache_shared_${BUILDKITE_ORGANIZATION_SLUG}_${BUILDKITE_PIPELINE_SLUG}"
   declare -r master_cache_volume="${shared_cache_volume_prefix}_${BUILDKITE_PIPELINE_DEFAULT_BRANCH}"
@@ -110,7 +117,10 @@ export TIMEOUT_MINUTES=$timeout_minutes
 # Note that artifacts can be overwritten when triggering a rebuild. This is no
 # different from managed artifact storage.
 #
-if [[ "${BUILDKITE_BRANCH}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]
+if [[ -n "${BUILDKITE_TAG}" ]]
+then
+    declare -r artifact_scope="${BUILDKITE_TAG}"
+elif [[ "${BUILDKITE_BRANCH}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]
 then
     declare -r artifact_scope="${BUILDKITE_PIPELINE_DEFAULT_BRANCH}/${BUILDKITE_COMMIT}"
 else


### PR DESCRIPTION
Fixes #89

Binary artifacts and docker images are identified by `BUILDKITE_TAG` for tag builds. Since the usage of `BUILDKITE_TAG` in artifact paths and docker image tags imposes some limitations on the format we validate the format at the start of a build. Alternatively, we could sanitize `BUILDKITE_TAG` or refuse to upload artifacts when the value is not valid. Failing seems to be the most straightforward option.