### PR TITLE
Upgrade node to the newest master

### DIFF
--- a/registry/devnet/main.tf
+++ b/registry/devnet/main.tf
@@ -1,5 +1,5 @@
 locals {
-  node_image = "gcr.io/opensourcecoin/radicle-registry/node:55c2f5b00673e8634e7e937470e6634b4233c4a2"
+  node_image = "gcr.io/opensourcecoin/radicle-registry/node:a2032853cb78d0fbfb15e636df6c213ff795d8f7 "
 }
 
 resource "google_container_cluster" "radicle-registry-devnet" {

--- a/registry/ffnet/main.tf
+++ b/registry/ffnet/main.tf
@@ -3,7 +3,7 @@ variable "project" {
 }
 
 locals {
-  node_image = "gcr.io/opensourcecoin/radicle-registry/node:704252ba638b2aa46c221c3172132cb2a97a44e7"
+  node_image = "gcr.io/opensourcecoin/radicle-registry/node:a2032853cb78d0fbfb15e636df6c213ff795d8f7"
 }
 
 provider "google-beta" {

--- a/registry/ffnet/miners.tf
+++ b/registry/ffnet/miners.tf
@@ -7,7 +7,6 @@
 resource "kubernetes_deployment" "miner" {
   lifecycle {
     ignore_changes = [
-      spec[0].template[0].spec[0].container[0].image,
       spec[0].replicas,
     ]
   }

--- a/registry/ffnet/rpc-api.tf
+++ b/registry/ffnet/rpc-api.tf
@@ -28,12 +28,6 @@ resource "kubernetes_service" "node-rpc" {
 }
 
 resource "kubernetes_deployment" "rpc-server" {
-  lifecycle {
-    ignore_changes = [
-      spec[0].template[0].spec[0].container[0].image,
-    ]
-  }
-
   metadata {
     name = "rpc-server"
     labels = {

--- a/registry/ffnet/validators.tf
+++ b/registry/ffnet/validators.tf
@@ -18,10 +18,6 @@ resource "kubernetes_service" "validator" {
 
 
 resource "kubernetes_stateful_set" "validator" {
-  lifecycle {
-    ignore_changes = [spec[0].template[0].spec[0].container[0].image]
-  }
-
   metadata {
     name = "validator"
   }


### PR DESCRIPTION
This PR upgrades the node images tags. Neither on devnet nor on ffnet it should require a hard chain reset.

I'm not sure what to do next, will k8s notice that the files have changed and switch to the newer binary or do I have to do something manually? I couldn't find any documentation for that, maybe I should add it in this PR too.