### PR TITLE
Don't use uniform hook wrapper script

### DIFF
--- a/ci/.debian/postinst
+++ b/ci/.debian/postinst
@@ -3,9 +3,20 @@ set -eou pipefail
 
 mkdir -p /etc/buildkite-hooks/hooks
 
-ln -sf /usr/local/bin/buildkite-command-wrapper /etc/buildkite-hooks/hooks/command
-ln -sf /usr/local/bin/buildkite-command-wrapper /etc/buildkite-hooks/hooks/pre-checkout
-ln -sf /usr/local/bin/buildkite-command-wrapper /etc/buildkite-hooks/hooks/pre-exit
+link_hooks() {
+  for hook in pre-checkout command pre-exit
+  do
+    hook_path=/etc/buildkite-hooks/hooks/${hook}
+    if [[ -e "${hook_path}" ]]
+    then
+      echo "${hook_path}" exists
+      exit 1
+    fi
+
+    echo '#!/usr/bin/env bash' > ${hook_path}
+    echo "exec \"/var/lib/buildkite-hooks/bin/buildkite-${hook}-hook\"" >> ${hook_path}
+  done
+}
 
 
 services() {

--- a/ci/.debian/prerm
+++ b/ci/.debian/prerm
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-rm -f /usr/local/bin/buildkite-command-hook
-rm -f /usr/local/bin/buildkite-pre-checkout-hook
-rm -f /usr/local/bin/buildkite-pre-exit-hook
+for hook in pre-checkout command pre-exit
+do
+  rm "/etc/buildkite-hooks/hooks/${hook}"
+done

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -29,7 +29,6 @@ depends = "$auto, buildkite-agent, containerd.io, docker-ce-cli, kata-proxy, kat
 priority = "optional"
 maintainer-scripts = ".debian"
 assets = [
-    ["scripts/buildkite-hook-wrapper", "usr/local/bin/", "755"],
     ["target/release/buildkite-command-hook", "var/lib/buildkite-hooks/bin/", "755"],
     ["target/release/buildkite-pre-checkout-hook", "var/lib/buildkite-hooks/bin/", "755"],
     ["target/release/buildkite-pre-exit-hook", "var/lib/buildkite-hooks/bin/", "755"],

--- a/ci/scripts/buildkite-hook-wrapper
+++ b/ci/scripts/buildkite-hook-wrapper
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eou pipefail
-
-declare -r script_name="${0##*/}"
-
-declare -rx RUST_BACKTRACE=1
-declare -rx RUST_LOG=info
-exec "/var/lib/buildkite-hooks/bin/buildkite-${script_name}-hook"


### PR DESCRIPTION
Instead of using _one_ wrapper script that delegates to the rust hooks and install it through symlinks we create a wrapper script for each hook on the fly.

The previous approach did not work because the buildkite agent _copied_ the hook to a temporary location with an opaque filename. Hence it was not possible to determine the hook by inspecting `$0`.