### PR TITLE
Distribute mining pods between all mining nodes

### DIFF
--- a/registry/devnet/main.tf
+++ b/registry/devnet/main.tf
@@ -1,5 +1,5 @@
 locals {
-  node_image = "gcr.io/opensourcecoin/radicle-registry/node:c8564b7c9ab1db9563dc138bd31e7b1db0bf2ed1 "
+  node_image = "gcr.io/opensourcecoin/radicle-registry/node:c8564b7c9ab1db9563dc138bd31e7b1db0bf2ed1"
 }
 
 resource "google_container_cluster" "radicle-registry-devnet" {

--- a/registry/devnet/miners.tf
+++ b/registry/devnet/miners.tf
@@ -54,6 +54,30 @@ resource "kubernetes_deployment" "devnet-miner" {
           operator = "Exists"
         }
 
+        # We want mining pods to be spread evenly across all mining
+        # nodes. To achieve this we make mining pods anti affine to
+        # themselves.
+        affinity {
+          pod_anti_affinity {
+            preferred_during_scheduling_ignored_during_execution {
+              weight = 100
+
+              pod_affinity_term {
+                label_selector {
+                  match_expressions {
+                    key      = "app"
+                    operator = "In"
+                    values   = ["miner"]
+                  }
+                }
+
+                topology_key = "kubernetes.io/hostname"
+              }
+            }
+          }
+        }
+
+
         container {
           image = local.node_image
           name  = "radicle-registry-node"

--- a/registry/ffnet/miners.tf
+++ b/registry/ffnet/miners.tf
@@ -51,6 +51,30 @@ resource "kubernetes_deployment" "miner" {
           operator = "Exists"
         }
 
+        # We want mining pods to be spread evenly across all mining
+        # nodes. To achieve this we make mining pods anti affine to
+        # themselves.
+        affinity {
+          pod_anti_affinity {
+            preferred_during_scheduling_ignored_during_execution {
+              weight = 100
+
+              pod_affinity_term {
+                label_selector {
+                  match_expressions {
+                    key      = "app"
+                    operator = "In"
+                    values   = ["miner"]
+                  }
+                }
+
+                topology_key = "kubernetes.io/hostname"
+              }
+            }
+          }
+        }
+
+
         container {
           image   = local.node_image
           name    = "radicle-registry-node"


### PR DESCRIPTION
At the moment the Kubernetes scheduler puts _all_ mining on one node in the mining pool. If this node is pre-empted all miners go down and it takes some time for them to start up and re-sync. This results in significant drops in the block rate which in turn triggers alerts.

By declaring [anti-affinity][1] for the mining pods we force the Kubernetes scheduler to distribute the mining pods evenly between the mining nodes. This means that if one node is pre-empted not all miners
go down.

[1]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/