### PR TITLE
Aggregate block import rate for alerting

### DIFF
--- a/registry/ffnet/grafana_alerts.md
+++ b/registry/ffnet/grafana_alerts.md
@@ -50,11 +50,12 @@ substrate_sub_libp2p_peers_count{kubernetes_cluster="ffnet", kubernetes_pod_labe
 Check if blocks are being mined correctly and that the chain is growing at a sensible rate
 ### Trigger
 In the past 15 minutes the `substrate_block_height` metric of a validator node has grown
-by less than 1 or more than 30. This is triggered only if the node is running, i.e. the `up` metric
-has the value of `1` and in the past 17 minutes the node wasn't major syncing.
+by less than 1 or more than 30.
 ### Query
 ```promql
-rate(substrate_block_height { kubernetes_cluster = "ffnet", status = "best", kubernetes_pod_label_app="validator" }[15m]) * 15 * 60 and on (instance) up{ kubernetes_cluster = "ffnet" } == 1 and on (instance) (max_over_time(substrate_sub_libp2p_is_major_syncing{ kubernetes_cluster = "ffnet" }[17m]) == 0)
+sum by (instance) (rate(
+  substrate_block_height{kubernetes_cluster="ffnet", status="best", kubernetes_pod_label_app="validator"}[15m]
+)) * 15 * 60",
 ```
 
 ## Blocks are imported in invalid rate in 60 minute window
@@ -64,9 +65,10 @@ rate(substrate_block_height { kubernetes_cluster = "ffnet", status = "best", kub
 Check if blocks are being mined correctly and that the chain is growing at a sensible rate
 ### Trigger
 In the past 1 hour the `substrate_block_height` metric of a validator node has grown
-by less than 35 or more than 80. This is triggered only if the node is running, i.e. the `up` metric
-has the value of `1` and in the past 1 hour and 1 minute the node wasn't major syncing.
+by less than 35 or more than 80.
 ### Query
 ```promql
-rate(substrate_block_height { kubernetes_cluster = "ffnet", status = "best", kubernetes_pod_label_app="validator" }[1h]) * 60 * 60 and on (instance) up{ kubernetes_cluster = "ffnet" } == 1 and on (instance) (max_over_time(substrate_sub_libp2p_is_major_syncing{ kubernetes_cluster = "ffnet" }[61m]) == 0)
+sum by (instance) (rate(
+  substrate_block_height{kubernetes_cluster="ffnet", status="best", kubernetes_pod_label_app="validator"}[1h]
+)) * 60 * 60",
 ```

--- a/registry/ffnet/grafana_alerts_dashboard.json
+++ b/registry/ffnet/grafana_alerts_dashboard.json
@@ -63,6 +63,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "grafanacloud-radicle-prom",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -226,6 +232,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "grafanacloud-radicle-prom",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -391,6 +403,12 @@
       "dashes": false,
       "datasource": "grafanacloud-radicle-prom",
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -426,7 +444,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(substrate_block_height { kubernetes_cluster = \"ffnet\", status = \"best\", kubernetes_pod_label_app=\"validator\" }[15m]) * 15 * 60 and on (instance) up{ kubernetes_cluster = \"ffnet\" } == 1 and on (instance) (max_over_time(substrate_sub_libp2p_is_major_syncing{ kubernetes_cluster = \"ffnet\" }[17m]) == 0)",
+          "expr": "sum by (instance) (rate(substrate_block_height { kubernetes_cluster = \"ffnet\", status = \"best\", kubernetes_pod_label_app=\"validator\" }[15m])) * 15 * 60",
           "hide": false,
           "interval": "",
           "legendFormat": "{{ instance }}",
@@ -553,6 +571,12 @@
       "dashes": false,
       "datasource": "grafanacloud-radicle-prom",
       "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -588,7 +612,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(substrate_block_height { kubernetes_cluster = \"ffnet\", status = \"best\", kubernetes_pod_label_app=\"validator\" }[1h]) * 60 * 60 and on (instance) up{ kubernetes_cluster = \"ffnet\" } == 1 and on (instance) (max_over_time(substrate_sub_libp2p_is_major_syncing{ kubernetes_cluster = \"ffnet\" }[61m]) == 0)",
+          "expr": "sum by (instance) (rate(substrate_block_height { kubernetes_cluster = \"ffnet\", status = \"best\", kubernetes_pod_label_app=\"validator\" }[1h])) * 60 * 60",
           "hide": false,
           "interval": "",
           "legendFormat": "{{ instance }}",
@@ -659,7 +683,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",
@@ -674,8 +697,5 @@
   "timezone": "",
   "title": "Alerts dashboard",
   "uid": "aCkUKReZz",
-  "variables": {
-    "list": []
-  },
-  "version": 54
+  "version": 55
 }


### PR DESCRIPTION
We adjust the queries for the block import rate so that we don’t receive alerts when validator pods are updated.

When the Kubernetes statefulset for the validators is updated the new pods have labels that differ from the old pods. This results in two timeseries for, say, the `validator-0` instance. With the previous query for block import rate the rate of the timeseries for the old pod would steadily decline after the pod was deleted and the rate for the new pod would start at zero and steadily rise (see figure below). By summing the old and new pod for a given instance we can counteract this and get the correct value.

We also remove redundant checks for uptime and syncing.

![unnamed](https://user-images.githubusercontent.com/3919579/84359626-32f64d00-abc9-11ea-8f1d-0caef8040221.png)
