### PR TITLE
Use proper configuration for systemd unit

### DIFF
--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -28,6 +28,7 @@ copyright = "2020 Kim Altintop, Monadic GmbH"
 depends = "$auto, buildkite-agent, containerd.io, docker-ce-cli, kata-proxy, kata-runtime, kata-shim, sops, zockervols"
 priority = "optional"
 maintainer-scripts = ".debian"
+conf-files = ["/etc/buildkite-hooks/buildkite-agent.cfg"]
 assets = [
     ["target/release/buildkite-command-hook", "var/lib/buildkite-hooks/bin/", "755"],
     ["target/release/buildkite-pre-checkout-hook", "var/lib/buildkite-hooks/bin/", "755"],

--- a/ci/etc/buildkite-hooks/buildkite-agent.cfg
+++ b/ci/etc/buildkite-hooks/buildkite-agent.cfg
@@ -3,3 +3,4 @@ build-path="/mnt/builds"
 hooks-path="/etc/buildkite-hooks/hooks"
 no-plugins=true
 no-local-hooks=true
+# tags="key1=value1,key2=value2"

--- a/ci/etc/systemd/system/buildkite-agent@.service.d/local.conf
+++ b/ci/etc/systemd/system/buildkite-agent@.service.d/local.conf
@@ -1,2 +1,3 @@
 [Service]
 EnvironmentFile = /etc/systemd/system/buildkite-agent@.service.d/token.env
+Environment=BUILDKITE_AGENT_CONFIG=/etc/buildkite-hooks/buildkite-agent.cfg


### PR DESCRIPTION
The buildkite-agent systemd service now uses the config file that we provide. We also make the file a debian conffile so that it is not overwritten on package updates.