### PR TITLE
jq dependency and tmpfs exec

### DIFF
--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -27,7 +27,7 @@ users = "0.9"
 [package.metadata.deb]
 maintainer = "Monadic GmbH <team@monadic.xyz>"
 copyright = "2020 Kim Altintop, Monadic GmbH"
-depends = "$auto, buildkite-agent, containerd.io, docker-ce-cli, kata-proxy, kata-runtime, kata-shim, sops, zockervols"
+depends = "$auto, buildkite-agent, containerd.io, docker-ce-cli, kata-proxy, kata-runtime, kata-shim, jq, sops, zockervols"
 priority = "optional"
 maintainer-scripts = ".debian"
 conf-files = ["/etc/buildkite-hooks/buildkite-agent.cfg"]

--- a/ci/src/container/docker.rs
+++ b/ci/src/container/docker.rs
@@ -258,7 +258,7 @@ fn render_mount_arg(mount: &Mount) -> String {
             size_in_bytes,
             mode,
         } => format!(
-            "--mount=type=tmpfs,dst={},tmpfs-size={},tmpfs-mode={:o}",
+            "--tmpfs={}:size={},mode={:o},exec",
             dst.display(),
             size_in_bytes,
             mode


### PR DESCRIPTION
* Mount tmpfs with 'exec' option. This makes it possible to make files in /tmp executable. It is required to run Rust doc tests.
* Add `jq` as dependency