### PR TITLE
Tear down devnet

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -12,10 +12,10 @@ Managed Infrastructure
 * KMS key for managing
   * CI secrets in the [`radicle-registry`][radicle-registry] repository. See `./kms-ci.tf`.
   * Secrets in this repository. See `./kms-infra.tf`
-* GKE cluster `radicle-registry-devnet` for running a devnet that we can play
-  around with. See `./devnet`.
 * GKE cluster `radicle-registry-ffnet` for running the FFnet information. See `./ffnet`.
 * DNS zones in `./dns.tf`
+* Currently not provisioned: GKE cluster `radicle-registry-devnet` for running a
+  devnet that we can play around with. See `./devnet`.
 
 Run `terraform output` for information about entry points.
 

--- a/registry/ffnet/main.tf
+++ b/registry/ffnet/main.tf
@@ -33,7 +33,7 @@ resource "google_container_node_pool" "pool-1" {
   provider   = google-beta
   cluster    = google_container_cluster.ffnet.name
   name       = "pool-1"
-  node_count = 2
+  node_count = 1
   node_config {
     machine_type = "n1-standard-2"
   }

--- a/registry/main.tf
+++ b/registry/main.tf
@@ -2,10 +2,6 @@ locals {
   project = "radicle-registry-dev"
 }
 
-module "devnet" {
-  source = "./devnet"
-}
-
 module "ffnet" {
   source  = "./ffnet"
   project = local.project


### PR DESCRIPTION
Since development on the registry is frozen we tear down the devnet for
the moment.