### PR TITLE
Kata maintenance

### DIFF
--- a/ci/provision/cloud-init.yaml
+++ b/ci/provision/cloud-init.yaml
@@ -31,6 +31,7 @@ apt:
     kata-containers.list:
       source: 'deb https://download.opensuse.org/repositories/home:/katacontainers:/releases:/x86_64:/master/xUbuntu_20.04/ /'
       keyid: 9FDC0CB63708CF803696E2DCD0B37B826063F3ED
+      keyserver: keyserver.ubuntu.com
     sops.list:
       source: 'deb https://dl.bintray.com/oscoin/sops buster main'
       keyid: 8756C4F765C9AC3CB6B85D62379CE192D401AB61

--- a/ci/provision/cloud-init.yaml
+++ b/ci/provision/cloud-init.yaml
@@ -29,7 +29,7 @@ apt:
       keyid: 54A647F9048D5688D7DA2ABE6A030B21BA07F4FB
       keyserver: keys.gnupg.net
     kata-containers.list:
-      source: 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/x86_64:/master/xUbuntu_18.04/ /'
+      source: 'deb https://download.opensuse.org/repositories/home:/katacontainers:/releases:/x86_64:/master/xUbuntu_20.04/ /'
       keyid: 9FDC0CB63708CF803696E2DCD0B37B826063F3ED
     sops.list:
       source: 'deb https://dl.bintray.com/oscoin/sops buster main'

--- a/ci/usr/bin/buildkite-hooks-setup
+++ b/ci/usr/bin/buildkite-hooks-setup
@@ -138,6 +138,7 @@ main() {
 
     echo "## Linking /etc/docker/daemon.json"
     ln -sf /usr/share/buildkite-hooks/docker-daemon.json /etc/docker/daemon.json
+    systemctl reload-or-restart docker.service
 
     echo "## Enabling systemd services"
     enable_systemd_services


### PR DESCRIPTION
* Use Ubuntu 20.04 repo for kata containers build and specify keyserver
* Restart docker when linking in configuration at setup