### PR TITLE
Set upload destination

### DIFF
--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -34,11 +34,13 @@ conf-files = ["/etc/buildkite-hooks/buildkite-agent.cfg"]
 assets = [
     ["usr/bin/*", "usr/bin/", "755"],
     ["target/release/buildkite-command-hook", "var/lib/buildkite-hooks/bin/", "755"],
+    ["target/release/buildkite-print-environment", "var/lib/buildkite-hooks/bin/", "755"],
     ["target/release/buildkite-pre-checkout-hook", "var/lib/buildkite-hooks/bin/", "755"],
     ["target/release/buildkite-pre-exit-hook", "var/lib/buildkite-hooks/bin/", "755"],
 
     ["etc/buildkite-hooks/buildkite-agent.cfg", "etc/buildkite-hooks/buildkite-agent.cfg", "644"],
     ["etc/buildkite-hooks/secrets.env", "etc/buildkite-hooks/secrets.env", "644"],
+    ["etc/buildkite-hooks/hooks/environment", "etc/buildkite-hooks/hooks/environment", "644"],
 
     ["etc/systemd/system/*.service", "etc/systemd/system/", "644"],
     ["etc/systemd/system/*.timer", "etc/systemd/system/", "644"],

--- a/ci/etc/buildkite-hooks/hooks/environment
+++ b/ci/etc/buildkite-hooks/hooks/environment
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export $(/var/lib/buildkite-hooks/bin/buildkite-print-environment)

--- a/ci/src/bin/buildkite-print-environment.rs
+++ b/ci/src/bin/buildkite-print-environment.rs
@@ -1,0 +1,32 @@
+use buildkite_hooks::config::Config;
+use std::path::PathBuf;
+
+/// This command prints a list of `KEY=value` pairs that set the buildkite
+/// environment.
+///
+/// At the moment only the `BUILDKITE_ARTIFACT_UPLOAD_DESTINATION` is set.
+///
+/// This command is called by the `hooks/environment` shell script.
+#[paw::main]
+fn main(cfg: Config) {
+    println!(
+        "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION={}",
+        upload_destination(&cfg)
+    );
+}
+
+fn upload_destination(cfg: &Config) -> String {
+    let mut dest = PathBuf::from("builds.radicle.xyz/");
+    dest.push(cfg.buildkite_pipeline_slug.clone());
+
+    if let Some(tag) = &*cfg.tag {
+        dest.push(tag);
+    } else if cfg.branch == cfg.buildkite_pipeline_default_branch {
+        dest.push(cfg.branch.clone());
+        dest.push(cfg.commit.clone());
+    } else {
+        dest.push(cfg.buildkite_job_id.clone());
+    }
+
+    format!("gs://{}", dest.to_str().expect("Invalid upload path"))
+}

--- a/ci/src/config.rs
+++ b/ci/src/config.rs
@@ -145,6 +145,9 @@ pub struct Config {
 
     #[structopt(long, env = "BUILDKITE_PIPELINE_DEFAULT_BRANCH")]
     pub buildkite_pipeline_default_branch: String,
+
+    #[structopt(long, env = "BUILDKITE_JOB_ID")]
+    pub buildkite_job_id: String,
 }
 
 impl Config {


### PR DESCRIPTION
We set the upload destination according the shell-based implementation.

The `BUILDKITE_ARTIFACT_UPLOAD_DESTINATION` environment variable can only be configured by buildkite’s script-based environment export. This is why we introduce the `buildkite-print-environment` command that is called by the `hooks/environment` script.