### PR TITLE
Update macOS build host setup instructions

### DIFF
--- a/ci/macos/usr/local/etc/buildkite-agent/hooks/environment
+++ b/ci/macos/usr/local/etc/buildkite-agent/hooks/environment
@@ -9,7 +9,30 @@ if [[ "${BUILDKITE_REPO}" != "https://github.com/radicle-dev/radicle-upstream" ]
   exit 1
 fi
 
-if [[ "${BUILDKITE_BRANCH}" != "master" ]]; then
+if [[ "${BUILDKITE_BRANCH}" != "master" && -z "${BUILDKITE_TAG}" ]]; then
   echo "Branch not allowed: ${BUILDKITE_BRANCH}"
   exit 1
 fi
+
+# Artifacts
+#
+# We're storing artifacts in our own GCS bucket in order to get predictable
+# download URLs. However, in order to not having to deal with sanitising branch
+# names, this applies only to `master` (that is,
+# BUILDKITE_PIPELINE_DEFAULT_BRANCH) builds. All other branches are scoped by
+# BUILDKITE_JOB_ID, as is the default.
+#
+# Note that artifacts can be overwritten when triggering a rebuild. This is no
+# different from managed artifact storage.
+#
+if [[ -n "${BUILDKITE_TAG}" ]]
+then
+    declare -r artifact_scope="${BUILDKITE_TAG}"
+elif [[ "${BUILDKITE_BRANCH}" == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]
+then
+    declare -r artifact_scope="${BUILDKITE_PIPELINE_DEFAULT_BRANCH}/${BUILDKITE_COMMIT}"
+else
+    declare -r artifact_scope="$BUILDKITE_JOB_ID"
+fi
+export BUILDKITE_GS_APPLICATION_CREDENTIALS=/etc/gce/cred.json
+export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="gs://builds.radicle.xyz/${BUILDKITE_PIPELINE_SLUG}/${artifact_scope}"


### PR DESCRIPTION
This adds instructions on how to set up GCP tagged build uploads and Apple notarization on a macOS build host.

Closes https://github.com/radicle-dev/radicle-upstream/issues/1530.

Here's a build after the configuration and setup had been applied:
https://buildkite.com/monadic/radicle-upstream/builds/8581#c39e7bdd-0260-4fdc-bce2-8b45c4fb5c99

And the build artefact was uploaded for a test branch:
https://storage.googleapis.com/builds.radicle.xyz/radicle-upstream/c39e7bdd-0260-4fdc-bce2-8b45c4fb5c99/dist/radicle-upstream-0.2.1.dmg