### PR TITLE
ci: mac agent builds release-candidate/ branches

### DIFF
--- a/ci/macos/usr/local/etc/buildkite-agent/hooks/environment
+++ b/ci/macos/usr/local/etc/buildkite-agent/hooks/environment
@@ -1,15 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "For security reasons this agent is only allowed to build"
-echo "the 'master' branch of 'https://github.com/radicle-dev/radicle-upstream'!"
+echo "For security reasons this agent is only allowed to build https://github.com/radicle-dev/radicle-upstream'!"
 
 if [[ "${BUILDKITE_REPO}" != "https://github.com/radicle-dev/radicle-upstream" ]]; then
   echo "Repository not allowed: ${BUILDKITE_REPO}"
   exit 1
 fi
 
-if [[ "${BUILDKITE_BRANCH}" != "master" && -z "${BUILDKITE_TAG}" ]]; then
+if [[ -n "${BUILDKITE_PULL_REQUEST_REPO}" && "${BUILDKITE_PULL_REQUEST_REPO}" != "https://github.com/radicle-dev/radicle-upstream" ]]; then
+  echo "Pull request from repository not allowed: ${BUILDKITE_PULL_REQUEST_REPO}"
+  exit 1
+fi
+
+if [[ "${BUILDKITE_BRANCH}" != "master" && "${BUILDKITE_BRANCH}" != release-candidate/* && -z "${BUILDKITE_TAG}" ]]; then
   echo "Branch not allowed: ${BUILDKITE_BRANCH}"
   exit 1
 fi


### PR DESCRIPTION
The MacOS build agent now is allowed to build branches that start with `release-candidate/`.

We also tighten permissions around pull requests. The code seemed to suggest that pull request were rejected by the `BUILDKITE_REPO` check. This is however not the case. For pull requests to the `radicle-upstream` repo the `BUILDKITE_REPO` variable is also set to the allowed value. Before, pull requests were rejected because `BUILDKITE_BRANCH` looks like `<repo>:<branch>`. We now make this more explicit.